### PR TITLE
Added attributes file to track bin file types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.blend filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.mat filter=lfs diff=lfs merge=lfs -text
+*.fbx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Adds the one new file that git needs to handle the LFS binary file storage module. LFS also needs to be installed on each machine, so I'll blast some instructions for how to do that out on Slack when this is approved.
